### PR TITLE
Make build should use vendor directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ lint:
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=mod -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
+	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=vendor -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
 
 .PHONY: verify
 verify:


### PR DESCRIPTION
`go build` should use `-mod=vendor` to build using the vendor directory.
Using `-mod=mod` will cause us to pull external dependencies during the build, which is blocked / prohibited in downstream CI.