### PR TITLE
Skip volume expansion if block node

### DIFF
--- a/pkg/ibmcsidriver/controller.go
+++ b/pkg/ibmcsidriver/controller.go
@@ -500,7 +500,15 @@ func (csiCS *CSIControllerServer) ControllerExpandVolume(ctx context.Context, re
 	if err != nil {
 		return nil, commonError.GetCSIError(ctxLogger, commonError.InternalError, requestID, err)
 	}
-	return &csi.ControllerExpandVolumeResponse{CapacityBytes: capacity, NodeExpansionRequired: true}, nil
+
+	nodeExpansionRequired := true
+	// if this is a raw block device, no expansion should be necessary on the node
+	cap := req.GetVolumeCapability()
+	if cap != nil && cap.GetBlock() != nil {
+		nodeExpansionRequired = false
+	}
+
+	return &csi.ControllerExpandVolumeResponse{CapacityBytes: capacity, NodeExpansionRequired: nodeExpansionRequired}, nil
 }
 
 // ControllerGetVolume ...


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
No expansion on the node should be necessary if device is of type raw block

**Release note**:
```
Skip volume expansion if device is of type raw block
```
