### PR TITLE
Add error object to describe log

### DIFF
--- a/pkg/ibmcsidriver/ibm_csi_driver.go
+++ b/pkg/ibmcsidriver/ibm_csi_driver.go
@@ -111,7 +111,7 @@ func (icDriver *IBMCSIDriver) SetupIBMCSIDriver(provider cloudProvider.CloudProv
 	// Set up Region
 	regionMetadata, err := nodeMeta(os.Getenv("KUBE_NODE_NAME"), lgr)
 	if err != nil {
-		return fmt.Errorf("Controller_Helper: Failed to initialize node metadata")
+		return fmt.Errorf("Controller_Helper: Failed to initialize node metadata: error: %v", err)
 	}
 	icDriver.region = regionMetadata.GetRegion()
 


### PR DESCRIPTION
`Test  Result`


{"level":"info","timestamp":"2022-05-30T12:27:27.954Z","caller":"ibmcsidriver/ibm_csi_driver.go:152","msg":"Adding node service capability","name":"ibm-vpc-block-csi-driver","CSIDriverName":"IBM VPC block driver","NodeServiceCapabilities":"GET_VOLUME_STATS"}
{"level":"info","timestamp":"2022-05-30T12:27:27.954Z","caller":"ibmcsidriver/ibm_csi_driver.go:152","msg":"Adding node service capability","name":"ibm-vpc-block-csi-driver","CSIDriverName":"IBM VPC block driver","NodeServiceCapabilities":"EXPAND_VOLUME"}
{"level":"info","timestamp":"2022-05-30T12:27:27.954Z","caller":"ibmcsidriver/ibm_csi_driver.go:156","msg":"Successfully added Node Service Capabilities","name":"ibm-vpc-block-csi-driver","CSIDriverName":"IBM VPC block driver"}
{"level":"info","timestamp":"2022-05-30T12:27:27.954Z","caller":"ibmcsidriver/ibm_csi_driver.go:109","msg":"Successfully setup IBM CSI driver","name":"ibm-vpc-block-csi-driver","CSIDriverName":"IBM VPC block driver"}
{**"level":"fatal","timestamp":"2022-05-30T12:27:28.028Z","caller":"cmd/main.go:109","msg":"Failed to initialize driver...","name":"ibm-vpc-block-csi-driver","CSIDriverName":"IBM VPC block driver","error":"Controller_Helper: Failed to initialize node metadata: error: One or few required node label(s) is/are missing [ibm-cloud.kubernetes.io/worker-id, failure-domain.beta.kubernetes.io/region, failure-domain.beta.kubernetes.io/zone]. Node Labels Found = [#map[beta.kubernetes.io/arch:amd64 beta.kubernetes.io/instance-type:bx2-4x16 beta.kubernetes.io/os:linux failure-domain.beta.kubernetes.io/region:eu-de ibm-cloud.kubernetes.io/vpc-instance-id:02b7_71109d99-0d55-460d-b9e3-7015abff9ab9 ibm-cloud.kubernetes.io/worker-id:02b7_71109d99-0d55-460d-b9e3-7015abff9ab9 kubernetes.io/arch:amd64 kubernetes.io/hostname:ipi-storage-40-jc76f-worker-1-ggpdk kubernetes.io/os:linux node-role.kubernetes.io/worker: node.kubernetes.io/instance-type:bx2-4x16 node.openshift.io/os_id:rhcos topology.kubernetes.io/region:eu-de topology.kubernetes.io/zone:eu-de-1 vpc-block-csi-driver-labels:true]]"}**
root@devmachine1:~/WORKSPACE/src/github.com/IBM/ibm-vpc-block-csi-driver-operator# 
