### PR TITLE
Reformat code with go 1.19

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package main ...
+// Package main ...
 package main
 
 import (

--- a/pkg/ibmcsidriver/constants.go
+++ b/pkg/ibmcsidriver/constants.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/controller.go
+++ b/pkg/ibmcsidriver/controller.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/controller_helper.go
+++ b/pkg/ibmcsidriver/controller_helper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (
@@ -109,7 +109,7 @@ func areVolumeCapabilitiesSupported(volCaps []*csi.VolumeCapability, driverVolum
 	return allSupported
 }
 
-//getVolumeParameters this function get the parameters from storage class, this also validate
+// getVolumeParameters this function get the parameters from storage class, this also validate
 // all parameters passed in storage class or not which are mandatory.
 func getVolumeParameters(logger *zap.Logger, req *csi.CreateVolumeRequest, config *config.Config) (*provider.Volume, error) {
 	var encrypt = "undef"

--- a/pkg/ibmcsidriver/controller_helper_test.go
+++ b/pkg/ibmcsidriver/controller_helper_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/controller_test.go
+++ b/pkg/ibmcsidriver/controller_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/ibm_csi_driver.go
+++ b/pkg/ibmcsidriver/ibm_csi_driver.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/ibm_csi_driver_test.go
+++ b/pkg/ibmcsidriver/ibm_csi_driver_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/identity.go
+++ b/pkg/ibmcsidriver/identity.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/identity_test.go
+++ b/pkg/ibmcsidriver/identity_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/node.go
+++ b/pkg/ibmcsidriver/node.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (
@@ -73,7 +73,7 @@ type VolumeStatUtils struct {
 type VolumeMountUtils struct {
 }
 
-//FSInfo ...
+// FSInfo ...
 func (su *VolumeStatUtils) FSInfo(path string) (int64, int64, int64, int64, int64, int64, error) {
 	return fs.Info(path)
 }

--- a/pkg/ibmcsidriver/node_helper.go
+++ b/pkg/ibmcsidriver/node_helper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (
@@ -93,8 +93,8 @@ func (csiNS *CSINodeServer) processMount(ctxLogger *zap.Logger, requestID, stagi
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-//This will handle raw block volume mounts
-//Incase of RAW volume mount, the Target will be devicefilepath  and NOT a mount directory.
+// This will handle raw block volume mounts
+// Incase of RAW volume mount, the Target will be devicefilepath  and NOT a mount directory.
 // The mountType is "bind" mount and will not specify any FORMAT(e.g ext4, ext3..)
 // e.g SOURCE (volume provider attached device on Host): /dev/xvde
 // e.g TARGET (SoftLink to User defined POD device /dev/sda) : "/var/data/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-9b82dced-fcd6-4181-968e-ae269e0f2311"

--- a/pkg/ibmcsidriver/node_test.go
+++ b/pkg/ibmcsidriver/node_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/server.go
+++ b/pkg/ibmcsidriver/server.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/pkg/ibmcsidriver/server_test.go
+++ b/pkg/ibmcsidriver/server_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//Package ibmcsidriver ...
+// Package ibmcsidriver ...
 package ibmcsidriver
 
 import (

--- a/tests/sanity/sanity_test.go
+++ b/tests/sanity/sanity_test.go
@@ -474,14 +474,14 @@ func (c *fakeProviderSession) AttachVolume(attachRequest provider.VolumeAttachme
 	return attachmentDetails, nil
 }
 
-//Detach detaches the volume/ fileset from the server
-//Its non bloking call and does not wait to complete the detachment
+// Detach detaches the volume/ fileset from the server
+// Its non bloking call and does not wait to complete the detachment
 func (c *fakeProviderSession) DetachVolume(detachRequest provider.VolumeAttachmentRequest) (*http.Response, error) {
 	return nil, nil
 }
 
-//WaitForAttachVolume waits for the volume to be attached to the host
-//Return error if wait is timed out OR there is other error
+// WaitForAttachVolume waits for the volume to be attached to the host
+// Return error if wait is timed out OR there is other error
 func (c *fakeProviderSession) WaitForAttachVolume(attachRequest provider.VolumeAttachmentRequest) (*provider.VolumeAttachmentResponse, error) {
 	if len(attachRequest.InstanceID) == 0 {
 		return nil, errors.New("no instance ID passed")
@@ -496,13 +496,13 @@ func (c *fakeProviderSession) WaitForAttachVolume(attachRequest provider.VolumeA
 	}, nil
 }
 
-//WaitForDetachVolume waits for the volume to be detached from the host
-//Return error if wait is timed out OR there is other error
+// WaitForDetachVolume waits for the volume to be detached from the host
+// Return error if wait is timed out OR there is other error
 func (c *fakeProviderSession) WaitForDetachVolume(detachRequest provider.VolumeAttachmentRequest) error {
 	return nil
 }
 
-//GetAttachAttachment retirves the current status of given volume attach request
+// GetAttachAttachment retirves the current status of given volume attach request
 func (c *fakeProviderSession) GetVolumeAttachment(attachRequest provider.VolumeAttachmentRequest) (*provider.VolumeAttachmentResponse, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Formatting rules were updated in go 1.19. Reformat the code so it's valid both in go 1.18 and 1.19.

`make verify` now passes with go version >= 1.18.0.