### PR TITLE
Update golint to 1.50

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 
 if [[ -z "$(command -v golangci-lint)" ]]; then
   echo "Cannot find golangci-lint. Installing golangci-lint..."
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0
   export PATH=$PATH:$(go env GOPATH)/bin
 fi
 


### PR DESCRIPTION
At least ver [1.48](https://github.com/golangci/golangci-lint/releases/tag/v1.48.0) is needed for go 1.19 support, bumping to 1.50 as it's the latest release.