### PR TITLE
WIP: snapshots should report restore size instead of actual size

### DIFF
--- a/vendor/github.com/IBM/ibmcloud-volume-vpc/block/provider/util.go
+++ b/vendor/github.com/IBM/ibmcloud-volume-vpc/block/provider/util.go
@@ -371,7 +371,7 @@ func FromProviderToLibSnapshot(vpcSnapshot *models.Snapshot, logger *zap.Logger)
 		VolumeID:             vpcSnapshot.SourceVolume.ID,
 		SnapshotID:           vpcSnapshot.ID,
 		SnapshotCreationTime: createdTime,
-		SnapshotSize:         GiBToBytes(vpcSnapshot.Size),
+		SnapshotSize:         GiBToBytes(vpcSnapshot.MinimumCapacity),
 		VPC:                  provider.VPC{Href: vpcSnapshot.Href},
 	}
 	if vpcSnapshot.LifecycleState == snapshotReadyState {


### PR DESCRIPTION
TODO: Update ibmcloud-volume-vpc module after library change is merged: https://github.com/IBM/ibmcloud-volume-vpc/pull/62