### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/deploy/kubernetes/driver/kubernetes/overlays/dev/controller-server-images.yaml
+++ b/deploy/kubernetes/driver/kubernetes/overlays/dev/controller-server-images.yaml
@@ -7,15 +7,15 @@ spec:
     spec:
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
         - name: csi-attacher
-          image:  k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image:  registry.k8s.io/sig-storage/csi-attacher:v3.5.0
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
         - name: iks-vpc-block-driver
           imagePullPolicy: Always
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
+          image: registry.k8s.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1

--- a/deploy/kubernetes/driver/kubernetes/overlays/dev/node-server-images.yaml
+++ b/deploy/kubernetes/driver/kubernetes/overlays/dev/node-server-images.yaml
@@ -8,8 +8,8 @@ spec:
       containers:
         - name: iks-vpc-block-node-driver
           imagePullPolicy: Always
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
+          image: registry.k8s.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
         - name: csi-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0

--- a/deploy/kubernetes/driver/kubernetes/overlays/release/controller-server-images.yaml
+++ b/deploy/kubernetes/driver/kubernetes/overlays/release/controller-server-images.yaml
@@ -7,15 +7,15 @@ spec:
     spec:
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
         - name: csi-attacher
-          image:  k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image:  registry.k8s.io/sig-storage/csi-attacher:v3.5.0
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
         - name: iks-vpc-block-driver
           imagePullPolicy: Always
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
+          image: registry.k8s.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1

--- a/deploy/kubernetes/driver/kubernetes/overlays/release/node-server-images.yaml
+++ b/deploy/kubernetes/driver/kubernetes/overlays/release/node-server-images.yaml
@@ -8,8 +8,8 @@ spec:
       containers:
         - name: iks-vpc-block-node-driver
           imagePullPolicy: Always
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
+          image: registry.k8s.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
         - name: csi-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0

--- a/deploy/kubernetes/driver/kubernetes/overlays/stable/controller-server-images.yaml
+++ b/deploy/kubernetes/driver/kubernetes/overlays/stable/controller-server-images.yaml
@@ -7,15 +7,15 @@ spec:
     spec:
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
         - name: csi-attacher
-          image:  k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image:  registry.k8s.io/sig-storage/csi-attacher:v3.5.0
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
         - name: iks-vpc-block-driver
           imagePullPolicy: Always
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
+          image: registry.k8s.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1

--- a/deploy/kubernetes/driver/kubernetes/overlays/stable/node-server-images.yaml
+++ b/deploy/kubernetes/driver/kubernetes/overlays/stable/node-server-images.yaml
@@ -8,8 +8,8 @@ spec:
       containers:
         - name: iks-vpc-block-node-driver
           imagePullPolicy: Always
-          image: k8s.gcr.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
+          image: registry.k8s.io/cloud-provider-ibm/ibm-vpc-block-csi-driver:v0.0.0
         - name: csi-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0

--- a/deploy/kubernetes/driver/kubernetes/overlays/stage/controller-server-images.yaml
+++ b/deploy/kubernetes/driver/kubernetes/overlays/stage/controller-server-images.yaml
@@ -7,15 +7,15 @@ spec:
     spec:
       containers:
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1
+          image: registry.k8s.io/sig-storage/csi-provisioner:v3.2.1
         - name: csi-attacher
-          image:  k8s.gcr.io/sig-storage/csi-attacher:v3.5.0
+          image:  registry.k8s.io/sig-storage/csi-attacher:v3.5.0
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.6.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.6.0
         - name: iks-vpc-block-driver
           imagePullPolicy: Always
           image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:master
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.5.0
+          image: registry.k8s.io/sig-storage/csi-resizer:v1.5.0
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1

--- a/deploy/kubernetes/driver/kubernetes/overlays/stage/node-server-images.yaml
+++ b/deploy/kubernetes/driver/kubernetes/overlays/stage/node-server-images.yaml
@@ -10,6 +10,6 @@ spec:
           imagePullPolicy: Always
           image: gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:master
         - name: csi-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.3.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.3.0


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/k8s.io/issues/4738

**Release note**:
```
Replace all `k8s.gcr.io` references with `registry.k8s.io`
```