### PR TITLE
configurable volume attachment limit

### DIFF
--- a/deploy/kubernetes/driver/kubernetes/manifests/config-map.yaml
+++ b/deploy/kubernetes/driver/kubernetes/manifests/config-map.yaml
@@ -60,6 +60,7 @@ data:
   CSIDriverRegistrarMemoryLimit: "80Mi"     #container:csi-driver-registrar, resource-type: memory-limit
   NodeDriverCPULimit: "120m"                #container:iks-vpc-block-node-driver, resource-type: cpu-limit
   NodeDriverMemoryLimit: "300Mi"            #container:iks-vpc-block-node-driver, resource-type: memory-limit
+  NodeDriverVolumeAttachmentLimit: "4"      #container:iks-vpc-block-node-driver, resource-type: volume-attach-limit
   LivenessProbeCPULimit: "20m"              #container:liveness-probe, resource-type: cpu-limit
   LivenessProbeMemoryLimit: "40Mi"          #container:liveness-probe, resource-type: memory-limit
   SecretSidecarCPULimit: "40m"              #container:storage-secret-sidecar, resource-type: cpu-limit

--- a/deploy/kubernetes/driver/kubernetes/manifests/node-server.yaml
+++ b/deploy/kubernetes/driver/kubernetes/manifests/node-server.yaml
@@ -66,6 +66,7 @@ spec:
           args:
             - "--v=5"
             - "--endpoint=unix:/csi/csi.sock"
+            - "--volume-attach-limit={{kube-system.addon-vpc-block-csi-driver-configmap.NodeDriverVolumeAttachmentLimit}}{{^kube-system.addon-vpc-block-csi-driver-configmap.NodeDriverVolumeAttachmentLimit}}80m{{/kube-system.addon-vpc-block-csi-driver-configmap.NodeDriverVolumeAttachmentLimit}}"
           env:
             - name: KUBE_NODE_NAME
               valueFrom:

--- a/pkg/ibmcsidriver/node.go
+++ b/pkg/ibmcsidriver/node.go
@@ -19,15 +19,15 @@ package ibmcsidriver
 
 import (
 	"fmt"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"k8s.io/klog/v2"
 
 	"os/exec"
 	"time"
@@ -354,8 +354,6 @@ func (csiNS *CSINodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInf
 	ctxLogger, requestID := utils.GetContextLogger(ctx, false)
 	ctxLogger.Info("CSINodeServer-NodeGetInfo... ", zap.Reflect("Request", *req))
 
-	// maxVolumesPerNode is the maximum number of volumes attachable to a node
-	var maxVolumesPerNode int64 = DefaultVolumesPerNode
 	nodeName := os.Getenv("KUBE_NODE_NAME")
 
 	nodeInfo := nodeMetadata.NodeInfoManager{
@@ -379,16 +377,8 @@ func (csiNS *CSINodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInf
 		},
 	}
 
-	// maxVolumesPerNode is the maximum number of volumes attachable to a node; default is 4
-	cores := runtime.NumCPU()
-	if cores >= MinimumCoresWithMaximumAttachableVolumes {
-		maxVolumesPerNode = MaxVolumesPerNode
-	}
-	ctxLogger.Info("Number of cores of the node and attachable volume limits.", zap.Reflect("Cores", cores), zap.Reflect("AttachableVolumeLimits", maxVolumesPerNode))
-
 	resp := &csi.NodeGetInfoResponse{
 		NodeId:             csiNS.Metadata.GetWorkerID(),
-		MaxVolumesPerNode:  maxVolumesPerNode,
 		AccessibleTopology: top,
 	}
 	ctxLogger.Info("NodeGetInfoResponse", zap.Reflect("NodeGetInfoResponse", resp))


### PR DESCRIPTION
some points  

1.) Default value is 80m if the value is not set by user that is wrong. 

- "--volume-attach-limit={{kube-system.addon-vpc-block-csi-driver-configmap.NodeDriverVolumeAttachmentLimit}}{{^kube-system.addon-vpc-block-csi-driver-configmap.NodeDriverVolumeAttachmentLimit}}80m{{/kube-system.addon-vpc-block-csi-driver-configmap.NodeDriverVolumeAttachmentLimit}}"


2.) Default value we can decide 4 or 12 but we can keep pending until we all the code working.

3.) We need to set the value --volume-attach-limit to MaxVolumesPerNode

	resp := &csi.NodeGetInfoResponse{
		NodeId:             csiNS.Metadata.GetWorkerID(),
		MaxVolumesPerNode:  maxVolumesPerNode,
		AccessibleTopology: top,
	}