### PR TITLE
pin golangci-lint version to v2.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ BUILD_NUMBER?=unknown
 GO111MODULE_FLAG?=on
 export GO111MODULE=$(GO111MODULE_FLAG)
 
-export LINT_VERSION="1.60.1"
+LINT_VERSION=v2.0.2
 
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
@@ -60,20 +60,18 @@ driver: deps buildimage
 .PHONY: deps
 deps:
 	echo "Installing dependencies ..."
-	@if ! which golangci-lint >/dev/null || [[ "$$(golangci-lint --version)" != *${LINT_VERSION}* ]]; then \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v${LINT_VERSION}; \
-	fi
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin ${LINT_VERSION}
 
 .PHONY: fmt
 fmt: lint
 	gofmt -l ${GOFILES}
 
 .PHONY: dofmt
-dofmt:
+dofmt: deps
 	$(GOPATH)/bin/golangci-lint run --disable-all --enable=gofmt --fix --timeout 600s
 
 .PHONY: lint
-lint:
+lint: deps
 	hack/verify-golint.sh
 
 .PHONY: build
@@ -81,7 +79,7 @@ build:
 	CGO_ENABLED=0 GOOS=$(shell go env GOOS) GOARCH=$(shell go env GOARCH) go build -mod=vendor -a -ldflags '-X main.vendorVersion='"${DRIVER_NAME}-${GIT_COMMIT_SHA}"' -extldflags "-static"' -o ${GOPATH}/bin/${EXE_DRIVER_NAME} ./cmd/
 
 .PHONY: verify
-verify:
+verify: deps
 	echo "Verifying and linting files ..."
 	./hack/verify-all.sh
 	echo "Congratulations! All Go source files have been linted."

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -15,16 +15,17 @@
 # limitations under the License.
 
 set -euo pipefail
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
-if [[ -z "$(command -v golangci-lint)" ]]; then
-  echo "Cannot find golangci-lint. Installing golangci-lint..."
-  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.60.1
-  export PATH=$PATH:$(go env GOPATH)/bin
+
+LINT_CMD=$(go env GOPATH)/bin/golangci-lint
+if [[ -z "$(command -v ${LINT_CMD})" ]]; then
+  echo "Cannot find ${LINT_CMD}"
+  exit 1
 fi
 
 echo "Verifying golint"
 readonly PKG_ROOT="$(git rev-parse --show-toplevel)"
 
-golangci-lint run --timeout=10m
+${LINT_CMD} version
+${LINT_CMD} run --timeout=10m
 
 echo "Congratulations! Lint check completed for all Go source files."


### PR DESCRIPTION
I opened a PR https://github.com/kubernetes-sigs/ibm-vpc-block-csi-driver/pull/219 to fix the linter errors on the latest version, but this brings up a related problem: `./hack/verify-golint.sh` always installs the `latest` version of `golangci-lint`, which can change the lint rules unexpectedly. This is a problem for older release branches for example, which typically only get important backports, but the linter rules may change at any time and block backport PR's.

This PR pins the `golangci-lint` version so that, going forward, the rules of the `build` and `verify` jobs do not change unexpectedly. Older release branches especially should stick with the same set of linter rules for the life of the release branch, unless there is good reason to change it.

/cc @arahamad @ambiknai
