### PR TITLE
fix v5.2: upgrades go version

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
-        go-version: '1.25.8'
+        go-version: '1.25.10'
     - name: Check out code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.25.8
+FROM golang:1.25.10
 
 WORKDIR /go/src/github.com/kubernetes-sigs/ibm-vpc-block-csi-driver
 ADD . /go/src/github.com/kubernetes-sigs/ibm-vpc-block-csi-driver

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ GIT_COMMIT_SHA="$(shell git rev-parse HEAD 2>/dev/null)"
 GIT_REMOTE_URL="$(shell git config --get remote.origin.url 2>/dev/null)"
 BUILD_DATE="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")"
 OSS_FILES := go.mod Dockerfile
-GOLANG_VERSION="1.25.8"
+GOLANG_VERSION="1.25.10"
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/ibm-vpc-block-csi-driver
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/IBM/ibm-csi-common v1.1.24


### PR DESCRIPTION
fixes the below CVE's
1. [CVE-2026-33811](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-33811)
2. [CVE-2026-39820](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-39820)
3. [CVE-2026-33814](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-33814)
4. [CVE-2026-39836](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-39836)
5. [CVE-2026-42499](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-42499)
6. [CVE-2026-39823](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-39823)
7. [CVE-2026-39826](https://exchange.xforce.ibmcloud.com/vulnerabilities/CVE-2026-39826)